### PR TITLE
Use l-prefixed functions and move not in snippet

### DIFF
--- a/src/chapter_3.md
+++ b/src/chapter_3.md
@@ -630,19 +630,18 @@ lAnd = lexeme $ void $ chunk "and"
 lOr :: Parser ()
 lOr = lexeme $ void $ chunk "or"
 
+lNot :: Parser ()
+lNot = lexeme $ void $ chunk "not"
+
 pBool :: Parser Bool
 pBool =
   choice
     [ do
-        chunk "true"
+        lTrue
         pure True,
       do
-        chunk "false"
+        lFalse
         pure False,
-      do
-        chunk "not"
-        e <- pBExp
-        pure $ Not e
     ]
 
 pBExp :: Parser BExp
@@ -659,7 +658,11 @@ pBExp =
         x <- pBExp
         lOr
         y <- pBExp
-        pure $ Or x y
+        pure $ Or x y,
+      do
+        lNot
+        e <- pBExp
+        pure $ Not e
     ]
 ```
 


### PR DESCRIPTION
I believe the code snippet that I have changed was previously slightly inconsistent (i.e. by not using the l-prefixed functions for true and false) and plain wrong (wrt. the not case in `pBool`).


I think the example following this snippet:
```
> runParser pBExp "not x"
Just (Var "not","x")
```
Should still do the same thing since the lVName parser still succeeds, but I have not checked it.